### PR TITLE
Modal Local Storage

### DIFF
--- a/home.js
+++ b/home.js
@@ -5,4 +5,18 @@ function toggleModal() {
     instance.open();
 };
 
-toggleModal();
+var visitor = localStorage.getItem("hasVisited");
+if (!visitor){
+    console.log("visitor value: " + visitor);
+    toggleModal();
+}
+
+
+$("#modal3").on("click", function(event) {
+    //is this necesarry?
+    event.preventDefault();
+    console.log("I don't know?");
+    localStorage.setItem("hasVisited",1)
+
+
+})


### PR DESCRIPTION
Got a simple localStorage value running with the entry modal for the home page. This way the user will be prompted once. Instead of forever.

We should double-check to make sure the modal still works as intended. I could get the re-direct to the hot coco page to work for me.